### PR TITLE
DRAFT jsmithb117/feature database redesign

### DIFF
--- a/server/db/models/conversationUsers.js
+++ b/server/db/models/conversationUsers.js
@@ -1,0 +1,21 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+//Sequelize sets and gets all required properties
+const ConversationUsers = db.define("conversation_user", {});
+
+ConversationUsers.findConversationUsers = async function (conversationId) {
+  const conversationUsersQuery = await ConversationUsers.findAll({
+    where: {
+      conversationId
+    }
+  });
+  const conversationUsers = [];
+  conversationUsersQuery.forEach(conversationUser => {
+    conversationUsers.push(conversationUser.userId);
+  });
+
+  return conversationUsers.length > 0 ? conversationUsers : null;
+};
+
+module.exports = ConversationUsers;

--- a/server/db/models/group.js
+++ b/server/db/models/group.js
@@ -1,0 +1,6 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+const Group = db.define("group", {});
+
+module.exports = Group;

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,17 +1,27 @@
 const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
+const ReadStatus = require("./readStatus");
+const Group = require("./group");
 
 // associations
 
-User.hasMany(Conversation);
-Conversation.belongsTo(User, { as: "user1" });
-Conversation.belongsTo(User, { as: "user2" });
-Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
+Conversation.hasMany(User);
+Message.belongsTo(Conversation);
+Message.belongsToMany(ReadStatus, { through: "message_read" });
+ReadStatus.belongsTo(Message, { through: "message_read" });
+User.hasMany(Message);
+User.hasMany(ReadStatus);
+Group.belongsTo(Conversation);
+Conversation.hasOne(Group);
+Group.belongsToMany(User, { through: "group_user" });
+User.hasMany(Group);
 
 module.exports = {
   User,
   Conversation,
-  Message
+  Message,
+  ReadStatus,
+  Group,
 };

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -2,26 +2,27 @@ const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
 const ReadStatus = require("./readStatus");
-const Group = require("./group");
+const ConversationUsers = require("./conversationUsers");
+const ReadStatusMessages = require("./readStatusMessages");
 
 // associations
 
-Conversation.hasMany(Message);
-Conversation.hasMany(User);
-Message.belongsTo(Conversation);
-Message.belongsToMany(ReadStatus, { through: "message_read" });
-ReadStatus.belongsTo(Message, { through: "message_read" });
-User.hasMany(Message);
 User.hasMany(ReadStatus);
-Group.belongsTo(Conversation);
-Conversation.hasOne(Group);
-Group.belongsToMany(User, { through: "group_user" });
-User.hasMany(Group);
+User.hasMany(Message);
+Message.belongsTo(User);
+Message.belongsTo(Conversation);
+Conversation.hasMany(Message);
+User.belongsToMany(Conversation, { through: ConversationUsers, foreignKey: 'userId' });
+Conversation.belongsToMany(User, { through: ConversationUsers, foreignKey: 'conversationId' });
+ReadStatus.belongsTo(User);
+ReadStatus.belongsToMany(Message, { through: ReadStatusMessages, foreignKey: 'readStatusId' });
+Message.belongsToMany(ReadStatus, { through: ReadStatusMessages, foreignKey: 'messageId' });
 
 module.exports = {
   User,
   Conversation,
   Message,
   ReadStatus,
-  Group,
+  ConversationUsers,
+  ReadStatusMessages,
 };

--- a/server/db/models/readStatus.js
+++ b/server/db/models/readStatus.js
@@ -2,6 +2,15 @@ const Sequelize = require("sequelize");
 const db = require("../db");
 
 //Sequelize sets and gets all required properties
-const ReadStatus = db.define("read_status", {});
+const ReadStatus = db.define("read_status", {
+  userId: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+  },
+  read: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false,
+  },
+});
 
 module.exports = ReadStatus;

--- a/server/db/models/readStatus.js
+++ b/server/db/models/readStatus.js
@@ -1,0 +1,7 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+//Sequelize sets and gets all required properties
+const ReadStatus = db.define("read_status", {});
+
+module.exports = ReadStatus;

--- a/server/db/models/readStatusMessages.js
+++ b/server/db/models/readStatusMessages.js
@@ -1,0 +1,16 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+//Sequelize sets and gets all required properties
+const ReadStatusMessages = db.define("read_status_messages", {
+});
+
+
+ReadStatusMessages.findReadStatuses = async function (messageId) {
+  const readStatuses = await ReadStatusMessages.findAll({
+    where: { messageId: messageId },
+  });
+
+  return readStatuses;
+}
+module.exports = ReadStatusMessages;


### PR DESCRIPTION
## Description

\\\\DRAFT////
Redesigns database to implement group conversations.
////DRAFT\\\\

## Notes on your approach and thought process
Approach and process:
 - Before we start to add the new functionality to the models, we should start by looking at how our Models relate and explain how the models currently work in English. Sequelize has named their association methods very well, which will make this easy.

 -  - User.hasMany(Conversation);
 -  - Conversation.belongsTo(User, { as: "user1" });
 -  - Conversation.belongsTo(User, { as: "user2" });
 -  - Message.belongsTo(Conversation);
 -  - Conversation.hasMany(Message);

 - Translated into English:
 -  - A user may have many Conversations.  A Conversation belongs to two users.  A Message belongs to a Conversation.  A Conversation may have many Messages.

 - If we want to add the ability to send group messages, we would want our Conversation to belong to many users.  Our plain language representation would look like:

 -  - A User may have many Conversations.  A Conversation may belong to many users.  A Message belongs to a Conversation.  A Conversation may have many messages.

 - The only difference is that a Conversation had two users, now it has many users.  Easy, right?  Not so fast.  We've just implemented a new 'read-message' feature that tracks whether the recipient has read each message.  What happens when a message has multiple recipients?  It's not very likely that we want to abandon this new feature, so we're going to have to figure out how to make it work.

 - We could create a new model that would track whether a single message has been read by a single User.  We could call this model ReadStatus (not a great name, I'm open to suggestions).  We can't just associate ReadStatus with Messages and Users.  For that, we'd need to create an intermediate Model.  We could call it UserRead.  Now, our plain-language representation of our Models would look like:

 -  - A User may have many Conversations.  A Conversation may belong to many users.  A Message belongs to one Conversation.  A Conversation may have many messages.  A Message has many UserReads.  A UserRead belongs to one Message.  A UserRead has one ReadStatus.  A ReadStatus belongs to one User.  A User may have many Reads.

 - But the docs say that this would break Eager Loading, which is how we currently fetch data and we'd like to keep it that way, so we need to change it up a bit.  We need to use what the Sequelize documentation refers to as a "Super Many-to-Many relationship." In English, these relationships are:

 -  - A Conversation may have many Messages.  A Conversation may have many Users.  A Message belongs to one Conversation.  A Message may belong to many Reads (through MessageRead).  A ReadStatus may belong to a Message(through MessageRead).  A User may have many Messages.  A user may have many ReadStatuses.

 - This way, we can continue to use eager loading, keeping latency closer to optimal.

 - Since we also have a many-many relationship between Conversations and Users and we'd like to continue to use eager loading, we need to implement a super many-many relationship between them.

 - A Conversation may belong to many Users through a UserConversation table.  A User may belong to many Conversations through a UserConversation table.

 - Our final plain language representation will be:

 - A User may have many ReadStatuses.  A User may have many Messages.  A Message belongs to one User.  A Message belongs to one Conversation.  A Conversation may have many Messages.  A Conversation may have many Users.  A User may belong to many Conversations through ConversationUser.  A Conversation may belong to many Users through ConversationUser.  A ReadStatus belongs to one User. A ReadStatus belongs to many Messages through ReadStatusMessage.  A Message belongs to many ReadStatuses through ReadStatusMessage.

 - Our Sequelize associations should look like:
 -  - User.hasMany(ReadStatus);
 -  - User.hasMany(Message);
 -  - Message.belongsTo(User);
 -  - Message.belongsTo(Conversation);
 -  - Conversation.hasMany(Message);
 -  - User.belongsToMany(Conversation, { through: ConversationUsers, foreignKey: 'userId' });
 -  - Conversation.belongsToMany(User, { through: ConversationUsers, foreignKey: 'conversationId' });
 -  - ReadStatus.belongsTo(User);
 -  - ReadStatus.belongsToMany(Message, { through: ReadStatusMessages, foreignKey: 'readStatusId' });
 -  - Message.belongsToMany(ReadStatus, { through: ReadStatusMessages, foreignKey: 'messageId' });

 - Without making a significant number of other changes on the server, I can't really test if this works as I intend it to.  I can seed it, and the shape of all the tables are as I expect, but I'm not sure if they work correctly.  ForeignKeys aren't required (Sequilize takes care of that) but a StackOverflow answer (https://stackoverflow.com/questions/22958683/how-to-implement-many-to-many-association-in-sequelize) brings up a good point.  It shows foreignKeys being assigned manually and explains that defining them here in code is helpful so the next engineer that comes along doesn't have to guess.  Explicit is usually better than implicit.
 -  -  -
Response to: "What additional (non-database) changes are needed..."

 - API:
 -  - Messages 'read' property could be renamed to 'usersReadStatus' and would need to be an array of objects that contain a 'userId' and 'read' boolean set for each user that is associated with the conversation the Message belongs to.  The ReadStatusMessages.findReadStatuses(messageId) method should facilitate this.

 - Server:
 -  - GET/api/conversations would need to be refactored to handle the new API and Models and shouldn't require new data.
 -  - POST/api/messages would need to be refactored to handle the new API and Models.  When creating a message, it should make a request to ConversationUser to get all userIds associated with it, as opposed to possibly getting bad data if we trusted the client to send it with the message.  Better yet, we could create ConversationUsers.findConversationUsers(conversationId) method that returns an array of userIds associated with that conversation.
 -  - PUT/api/messages would need to be refactored to handle the new API and Models and shouldn't require new data.
 - Client:
 -  - Groups:
 -  -  - Tons of questions first:
 -  -  -  - How do we create new groups?  Can only the creator of the group add new members or should anyone be able to?  Should we create the ability to remove another person from a group?  Should anyone get to do that or only the creator?  Could we have a 'vote' system where anyone can create a vote to remove someone but they only get removed if a certain percentage of users vote to kick?  Should a user be able to remove themself from a group?  Should groups be visible to others?  Should groups have a name?
 -  -  - I'll go on the following assumptions:
 -  -  -  - Any member of a Conversation can add other members directly to the Conversation.
 -  -  -  - The only way a user can be removed is if they remove themselves.
 -  -  -  - Groups do not have names, they're just conversations with many users.
 -  -  -  - Users who are not a part of a Conversation cannot view that conversation.

 -  -  - We'd need to add a place to create a new conversation, and then add other users to the conversation.  We could add a createGroup button just above the search box.  When clicked, it could turn green(?) and render each user (using the Chat component) but without passing a conversation prop so just the Avatar and username render, and have a big + render(Chat would need to be modified).  When a users '+' is clicked, that user could be highlighted, added to the conversation, and moved to the top of the list of users that pass the filter.  If the searchTerm changes, users that have been added to the conversation will still be deduplicated, ordered, rendered, highlighted, and remain at the top of the list.  If searchTerm.length is not zero, and the CreateGroup button has been checked, all users are rendered with '+' buttons.

 -  -  - ActiveChat could work mostly the same except for the Header component.  We could refactor that to render all users names smaller than it currently does if there is more than one other group member and have a max number of users it can render with ' and X more users...' if max is exceeded.

 -  -  - Sidebar would work a bit differently.  If there is only one other user in the conversation, it could render Chat as normal.  If there are more, we could either modify Chat or create a GroupChat component that would only render Avatars, but with a max of 3(?).  If there are 15 users in that conversation(user and 14 others), it would render the Avatar of the 3 other users who chatted most recently and the text "... and 11 other users" or similar.  Sidebar would also need a 'Leave Conversation' button that allows a user to leave a conversation, preferably with a confirmation (modal?) to minimize accidental removals.

 -  -  - Messages and OtherUserBubble might need some minor tweaks but could mostly be left alone.

 - Notifications:
 -  - Refactor the read status Avatar in SenderBubble to render multiple Avatars, maybe show only 4-5 Avatars max (or based on screen size).  If more, they render a modal on mouseover that renders all users that have read that message?
 -  - The shape of messages could be directly from the API: {text: "", usersReadStatus: [{ userId: 1, read: false}, {userId: 2, read: true}], ...}
 -  - conversation.latestMessageReadId would need to be an array of objects that contain a userId and a latestMessageReadId.
 -  - Refactor updating the new 'usersReadStatus' property of messages.
I'm sure this isn't an exhaustive list of the changes that would need to be done and I would most certainly welcome any feedback, but it seems like a solid start to me!

 -  -  -
Response to "If our app were already deployed...":

 - If our app were already deployed as an iOS or Android app and we changed the API, all previous versions of the app would break.  Since we only have a React client (for now at least), we could change the API at the same time we update the client without worrying about breaking things.  I don't know if I'd want to deploy a new client, server, and database at the same time though, it seems like a risky move.

 - After we've approved the new API, I'd update the server, the database, and the client in that order, load-testing on an offline duplicate of our server/database prior to each deployment.

 - First, I'd create a new database with the new models that will run in parallel to our existing database until all data has been migrated to the new database.

 - Then, I'd update the server to be able to handle requests from both the old API and the new API, storing the data from both in the new model.   Any time the server received a GET request, it would get it from the old database.  If the server received a POST, PUT, DELETE... request, it would update both the old and new databases.  This is where it gets tricky.  Obviously, the new database won't have any data.  Since Messages, Users, and Conversations are all inter-related, references to existing conversations wouldn't be there, so for any new Message that doesn't have a Conversation associated with it in the new database, the server would have to request the Conversation and all associated Users and insert that data into the new database in the new model. The same would apply to PUT requests.  All of this extra work may increase the load on the server and/or database significantly, at least temporarily, so we may need to scale them depending on how our load-testing went or use some other scheme like only migrating data to the new database if the server load is less than 85 - 90%.  If we find we need to scale and the server was already scaled horizontally, we could simply add an instance/s to the cluster and update the load balancer. If the server wasn't already scaled horizontally, we could vertically scale it temporarily if it's possible(ex: already using the largest EC2 instance).  If we haven't scaled horizontally and can't scale vertically, we'd need to add the capability to horizontally scale the server.

 - Now that we're posting data to the new database, handled any necessary scaling, and have worked out any kinks, we can migrate all data that's not already on the new database.  Once the new database has all the data (in the new model) as the old database, we could update the server, load-balancers, and/or proxies to only use the new database.  Then, we could update the client to have the functionality we need and deploy it.  After we've successfully deployed the new client and worked out any kinks, we could update the server to remove the old API.

## Further comments (optional)

I'm trying to find the balance between 'Put little effort into this.' and 'Perfect, but it took 3 weeks.'.  I'm shooting for 'Oooh, so close.  Just make these couple tweaks...'.  10 minutes of a Senior Engineer's time is worth a lot more than 10 minutes of a Junior Engineer's time, but 3 weeks of a Junior Engineers time is worth more than 10 minutes of a Senior Engineer's time. After all, this evaluation is intended to be an approximation of a work environment.

